### PR TITLE
Add Responsive to card detail

### DIFF
--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -83,10 +83,10 @@
   width: 100%;
 
   &::before {
-    bottom: 55px;
     content: url(/src/img/badge.png);
-    left: 57px;
     position: absolute;
+    right: -160px;
+    top: $badge-top;
     transform: rotate(15deg) scale($badge-scale);
   }
 }
@@ -112,7 +112,7 @@
 
   .image-container {
     &::before {
-      bottom: calc(#{$badge-bottom} * 1.3);
+      top: calc(#{$badge-top} * 1.07);
       transform: rotate(15deg) scale(calc(#{$badge-scale} * 0.7));
     }
   }

--- a/scss/styles.scss
+++ b/scss/styles.scss
@@ -1,4 +1,5 @@
 @import "colors";
+@import "variables";
 
 * {
   font-family: "Roboto", sans-serif;
@@ -77,17 +78,64 @@
 }
 
 .image-container {
+  max-width: 261px;
   position: relative;
+  width: 100%;
 
   &::before {
     bottom: 55px;
     content: url(/src/img/badge.png);
     left: 57px;
     position: absolute;
-    transform: rotate(15deg) scale(0.2);
+    transform: rotate(15deg) scale($badge-scale);
   }
 }
 
 .book-image {
-  width: 261px;
+  width: 100%;
+}
+
+@media only screen and (max-width: 1024px) {
+  .container {
+    align-items: center;
+    flex-direction: column-reverse;
+    padding: 35px 20px;
+    width: 100%;
+  }
+
+  .card-container {
+    align-items: center;
+    flex-direction: column;
+    padding-top: 50px;
+    width: 100%;
+  }
+
+  .image-container {
+    &::before {
+      bottom: calc(#{$badge-bottom} * 1.3);
+      transform: rotate(15deg) scale(calc(#{$badge-scale} * 0.7));
+    }
+  }
+
+  .book-info {
+    padding: 20px 0 0;
+    width: 100%;
+  }
+
+  .book-title {
+    font-size: 26px;
+  }
+
+  .book-description {
+    padding-top: 25px;
+  }
+
+  .book-attribute {
+    font-size: 15px;
+    margin-bottom: 22px;
+  }
+
+  .back-button {
+    margin: 20px 0 0;
+  }
 }

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,1 +1,3 @@
 $navbar-height: 70px;
+$badge-scale: 0.2;
+$badge-bottom: 55px;

--- a/scss/variables.scss
+++ b/scss/variables.scss
@@ -1,3 +1,3 @@
 $navbar-height: 70px;
 $badge-scale: 0.2;
-$badge-bottom: 55px;
+$badge-top: -240px;


### PR DESCRIPTION
# Layout Training
## Summary

Add Responsive to card detail when width on 1024px or less.

## Screenshot

![image](https://user-images.githubusercontent.com/19678474/74470135-f0677280-4e6b-11ea-9bd5-449945556fa3.png)

## Trello Card

https://trello.com/c/RULIa2Sd/34-responsive